### PR TITLE
增加监听svg更改的脚本

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -8,7 +8,7 @@ module.exports = (api, options, rootOptions) => {
     api.extendPackage({
       scripts: {
         'bootstrap': 'yarn --registry https://registry.npm.taobao.org || npm install --registry https://registry.npm.taobao.org || cnpm install',
-        'serve': 'vue-cli-service serve',
+        'serve': 'vue-cli-service serve & node ./scripts/watchSvgFiles.js',
         'build': 'node build/index.js',
         'zip': 'node build/zip.js',
         'lint': 'vue-cli-service lint',
@@ -71,7 +71,7 @@ module.exports = (api, options, rootOptions) => {
     api.extendPackage({
       scripts: {
         'bootstrap': 'yarn --registry https://registry.npm.taobao.org || npm install --registry https://registry.npm.taobao.org || cnpm install',
-        'serve': 'vue-cli-service serve',
+        'serve': 'vue-cli-service serve & node ./scripts/watchSvgFiles.js',
         'build': 'node build/index.ts',
         'zip': 'node build/zip.ts',
         'lint': 'vue-cli-service lint',

--- a/generator/template/scripts/watchSvgFiles.js
+++ b/generator/template/scripts/watchSvgFiles.js
@@ -1,0 +1,23 @@
+var fs = require('fs')
+var path = require('path')
+var {exec} = require('child_process')
+
+function debounce (fn, wait = 50) {
+  let timer = null
+  return function(...args) {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+          fn.apply(this, args)
+      }, wait)
+  }
+}
+
+var buildSvg = debounce(function () {
+  exec('npm run svg', function () {
+    console.log('添加SVG成功  >.<')
+  })
+}, 3000)
+
+fs.watch(path.resolve(__dirname, '../src/icons/svg'), function () {
+  buildSvg()
+})

--- a/generator/ts-template/scripts/watchSvgFiles.js
+++ b/generator/ts-template/scripts/watchSvgFiles.js
@@ -1,0 +1,23 @@
+var fs = require('fs')
+var path = require('path')
+var {exec} = require('child_process')
+
+function debounce (fn, wait = 50) {
+  let timer = null
+  return function(...args) {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+          fn.apply(this, args)
+      }, wait)
+  }
+}
+
+var buildSvg = debounce(function () {
+  exec('npm run svg', function () {
+    console.log('添加SVG成功  >.<')
+  })
+}, 3000)
+
+fs.watch(path.resolve(__dirname, '../src/icons/svg'), function () {
+  buildSvg()
+})


### PR DESCRIPTION
将 svg 文件复制到之前的 svg 文件夹里即可生成对应的js文件，不需要再去手动跑脚本 `npm run svg`